### PR TITLE
Update action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ branding:
   icon: "package"
   color: "red"
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
This PR updates the action runtime from `node20` to `node24` in `action.yml`.

GitHub is deprecating Node.js 20 for Actions runners, and all actions will be forced to run on Node.js 24 by default starting June 2nd, 2026. This change ensures `action-zip` continues to work without deprecation warnings.

The action's code (`adm-zip`, `@actions/core`) uses standard Node.js APIs that are fully compatible with Node.js 24 — no other changes are needed.

Closes #36